### PR TITLE
update blocks docs with some dropdown menu examples, fix a few things…

### DIFF
--- a/blocks-styles/dropdowns.styl
+++ b/blocks-styles/dropdowns.styl
@@ -11,23 +11,22 @@
 
 .dropdown-wrapper {
   display: inline-block;
-  margin: 24px 0;
 }
 
 .dropdown-description {
-  position: absolute;
-  top: -32px;
+  margin: 0;
 }
 
 .dropdown-trigger {
   position: relative;
   height: 40px;
-  border-radius: 7px;
+  border-radius: $base-border-radius;
   font-size: 16px;
   font-family: $sans-serif-font-family-normal;
   line-height: 20px;
   text-align: left;
   padding: 0 48px 0 16px;
+  margin: 0;
   cursor: pointer;
 
   &.disabled {
@@ -37,7 +36,7 @@
 
   &::after {
     position: absolute;
-    top: 12px;
+    top: 10px;
     right: 16px;
     content: "";
     display: inline-block;
@@ -53,6 +52,22 @@
   &.active::after {
     transform: rotate(180deg);
     transition: transform 300ms;
+  }
+  
+  &:hover, &.hover {
+    margin: 0 -1px;
+    
+    &::after {
+      top: 9px;
+    }
+  }
+  
+  &:focus, &.focus {
+    margin: 0;
+    
+    &::after {
+      top: 10px;
+    }
   }
 }
 
@@ -132,14 +147,14 @@
       color: $ui-01;
       background-color: $brand-01;
     }
-
-    &:hover, &.hover {
-      color: $ui-01;
-    }
   }
 
   &:hover, &.hover {
     background-color: $brand-01;
     color: $ui-01;
+    
+    * {
+      color: $ui-01;
+    }
   }
 }

--- a/blocks.css
+++ b/blocks.css
@@ -797,11 +797,9 @@ a.disabled {
 }
 .dropdown-wrapper {
   display: inline-block;
-  margin: 24px 0;
 }
 .dropdown-description {
-  position: absolute;
-  top: -32px;
+  margin: 0;
 }
 .dropdown-trigger {
   position: relative;
@@ -812,6 +810,7 @@ a.disabled {
   line-height: 20px;
   text-align: left;
   padding: 0 48px 0 16px;
+  margin: 0;
   cursor: pointer;
 }
 .dropdown-trigger.disabled {
@@ -820,7 +819,7 @@ a.disabled {
 }
 .dropdown-trigger::after {
   position: absolute;
-  top: 12px;
+  top: 10px;
   right: 16px;
   content: "";
   display: inline-block;
@@ -841,6 +840,22 @@ a.disabled {
   transition: -webkit-transform 300ms;
   transition: transform 300ms;
   transition: transform 300ms, -webkit-transform 300ms;
+}
+.dropdown-trigger:hover,
+.dropdown-trigger.hover {
+  margin: 0 -1px;
+}
+.dropdown-trigger:hover::after,
+.dropdown-trigger.hover::after {
+  top: 9px;
+}
+.dropdown-trigger:focus,
+.dropdown-trigger.focus {
+  margin: 0;
+}
+.dropdown-trigger:focus::after,
+.dropdown-trigger.focus::after {
+  top: 10px;
 }
 .dropdown-menu {
   position: absolute;
@@ -952,14 +967,6 @@ a.disabled {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
 }
-.dropdown-item *:hover {
-  color: #fff;
-  color: var(--ui-01, #fff);
-}
-.dropdown-item *.hover {
-  color: #fff;
-  color: var(--ui-01, #fff);
-}
 .dropdown-item:hover {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
@@ -969,6 +976,14 @@ a.disabled {
 .dropdown-item.hover {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
+  color: #fff;
+  color: var(--ui-01, #fff);
+}
+.dropdown-item:hover * {
+  color: #fff;
+  color: var(--ui-01, #fff);
+}
+.dropdown-item.hover * {
   color: #fff;
   color: var(--ui-01, #fff);
 }

--- a/docs/_styl/page.styl
+++ b/docs/_styl/page.styl
@@ -72,11 +72,6 @@
   .highlight {
     margin: 0;
   }
-  
-  button, a {
-    display: table;
-    margin: 12px 16px;
-  }
 }
 
 .left-nav-panel {

--- a/docs/components/dropdowns.html
+++ b/docs/components/dropdowns.html
@@ -154,7 +154,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="l-flex-vertical">
     <div class="l-flex-horizontal">
       <span class="doc-state-title">
-        Active
+        Default
       </span>
       <div class="doc-state-content">
         {{ dropdown_trigger_example }}

--- a/docs/components/dropdowns.html
+++ b/docs/components/dropdowns.html
@@ -7,13 +7,189 @@ definition: An input that allows users to make a single selection from a pre-def
 ---
 
 {% capture example %}
-  <div></div>
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <p class="dropdown-description">Here is a dropdown</p>
+      <button class="dropdown-trigger active">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu">
+        <li class="dropdown-item">
+          <button>Button option</button>
+        </li>
+        <li class="dropdown-item">
+          <a href="#">Link option</a>
+        </li>
+        <li class="dropdown-item disabled">
+          <button>Button option 2</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Link option 2</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture dropdown_trigger_example %}
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <button class="dropdown-trigger">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu hidden">
+        <li class="dropdown-item">
+          <button>Button option</button>
+        </li>
+        <li class="dropdown-item">
+          <a href="#">Link option</a>
+        </li>
+        <li class="dropdown-item disabled">
+          <button>Button option 2</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Link option 2</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture dropdown_trigger_hover_example %}
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <button class="dropdown-trigger hover">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu hidden">
+        <li class="dropdown-item">
+          <button>Button option</button>
+        </li>
+        <li class="dropdown-item">
+          <a href="#">Link option</a>
+        </li>
+        <li class="dropdown-item disabled">
+          <button>Button option 2</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Link option 2</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture dropdown_trigger_focus_example %}
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <button class="dropdown-trigger focus">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu hidden">
+        <li class="dropdown-item">
+          <button>Button option</button>
+        </li>
+        <li class="dropdown-item">
+          <a href="#">Link option</a>
+        </li>
+        <li class="dropdown-item disabled">
+          <button>Button option 2</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Link option 2</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture dropdown_trigger_disabled_example %}
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <button class="dropdown-trigger disabled">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu hidden">
+        <li class="dropdown-item">
+          <button>Button option</button>
+        </li>
+        <li class="dropdown-item">
+          <a href="#">Link option</a>
+        </li>
+        <li class="dropdown-item disabled">
+          <button>Button option 2</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Link option 2</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture dropdown_trigger_open_example %}
+  <div class="dropdown-wrapper">
+    <div class="dropdown">
+      <button class="dropdown-trigger active">
+        Choose an option
+      </button>
+      <ul class="dropdown-menu">
+        <li class="dropdown-item">
+          <button>One option</button>
+        </li>
+        <li class="dropdown-item disabled">
+          <a href="#">Disabled option</a>
+        </li>
+        <li class="dropdown-item hover">
+          <button>Best option</button>
+        </li>
+      </ul>
+    </div>
+  </div>
 {% endcapture %}
 
 <!-- state & behavior section -->
 <div class="l-flex-vertical doc-section">
   <span class="heading-medium">States & Behavior</span>
   <div class="l-flex-vertical">
+    <div class="l-flex-horizontal">
+      <span class="doc-state-title">
+        Active
+      </span>
+      <div class="doc-state-content">
+        {{ dropdown_trigger_example }}
+      </div>
+      <span class="doc-state-title">
+        Open
+      </span>
+      <div class="doc-state-content">
+        {{ dropdown_trigger_open_example }}
+      </div>
+    </div>
+    <div class="l-flex-horizontal">
+      <span class="doc-state-title">
+        Hover
+      </span>
+      <div class="doc-state-content">
+        {{ dropdown_trigger_hover_example }}
+      </div>
+    </div>
+    <div class="l-flex-horizontal">
+      <span class="doc-state-title">
+        Focus
+      </span>
+      <div class="doc-state-content">
+        {{ dropdown_trigger_focus_example }}
+      </div>
+    </div>
+    <div class="l-flex-horizontal">
+      <span class="doc-state-title">
+        Disabled
+      </span>
+      <div class="doc-state-content">
+        {{ dropdown_trigger_disabled_example }}
+      </div>
+    </div>
   </div>
 </div>
 

--- a/docs/css/blocks-docs.css
+++ b/docs/css/blocks-docs.css
@@ -797,11 +797,9 @@ a.disabled {
 }
 .dropdown-wrapper {
   display: inline-block;
-  margin: 24px 0;
 }
 .dropdown-description {
-  position: absolute;
-  top: -32px;
+  margin: 0;
 }
 .dropdown-trigger {
   position: relative;
@@ -812,6 +810,7 @@ a.disabled {
   line-height: 20px;
   text-align: left;
   padding: 0 48px 0 16px;
+  margin: 0;
   cursor: pointer;
 }
 .dropdown-trigger.disabled {
@@ -820,7 +819,7 @@ a.disabled {
 }
 .dropdown-trigger::after {
   position: absolute;
-  top: 12px;
+  top: 10px;
   right: 16px;
   content: "";
   display: inline-block;
@@ -841,6 +840,22 @@ a.disabled {
   transition: -webkit-transform 300ms;
   transition: transform 300ms;
   transition: transform 300ms, -webkit-transform 300ms;
+}
+.dropdown-trigger:hover,
+.dropdown-trigger.hover {
+  margin: 0 -1px;
+}
+.dropdown-trigger:hover::after,
+.dropdown-trigger.hover::after {
+  top: 9px;
+}
+.dropdown-trigger:focus,
+.dropdown-trigger.focus {
+  margin: 0;
+}
+.dropdown-trigger:focus::after,
+.dropdown-trigger.focus::after {
+  top: 10px;
 }
 .dropdown-menu {
   position: absolute;
@@ -952,14 +967,6 @@ a.disabled {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
 }
-.dropdown-item *:hover {
-  color: #fff;
-  color: var(--ui-01, #fff);
-}
-.dropdown-item *.hover {
-  color: #fff;
-  color: var(--ui-01, #fff);
-}
 .dropdown-item:hover {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
@@ -969,6 +976,14 @@ a.disabled {
 .dropdown-item.hover {
   background-color: #00b07d;
   background-color: var(--brand-01, #00b07d);
+  color: #fff;
+  color: var(--ui-01, #fff);
+}
+.dropdown-item:hover * {
+  color: #fff;
+  color: var(--ui-01, #fff);
+}
+.dropdown-item.hover * {
   color: #fff;
   color: var(--ui-01, #fff);
 }
@@ -1844,11 +1859,6 @@ a.disabled {
 }
 .snippet-container .highlight {
   margin: 0;
-}
-.snippet-container button,
-.snippet-container a {
-  display: table;
-  margin: 12px 16px;
 }
 .left-nav-panel {
   width: 400px;


### PR DESCRIPTION
… with the dropdowns

@hwigmore this adds a documentation page for dropdowns (they're not like, interactive b/c of JavaScript and things, but you can see the structure and what they look like)

Also fixed a few issues with dropdowns:
- the way the menus wiggle on hover b/c of the border width change
- got rid of some weird margins
- scooched up the arrow (it looked a little awkward in it's active state, like it was too low)
- some hover states on menu items weren't quite right

<img width="600" alt="screen shot 2018-06-27 at 5 16 24 pm" src="https://user-images.githubusercontent.com/7839369/42000183-ef13fad4-7a2d-11e8-9f7b-ccf38d93ee02.png">
