### PR TITLE
Propagate enter in onKeyUp for TextField

### DIFF
--- a/react/input/TextField.jsx
+++ b/react/input/TextField.jsx
@@ -78,6 +78,7 @@ class TextField extends React.Component {
             this.updateValidity();
           }
         }}
+        onKeyDown={this.props.onKeyDown}
       />
     );
 
@@ -114,6 +115,7 @@ TextField.propTypes = {
   invalidErrorMessage: PropTypes.string,
   onChange: PropTypes.func,
   onKeyUp: PropTypes.func,
+  onKeyDown: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   autoComplete: PropTypes.string,
@@ -133,6 +135,7 @@ TextField.defaultProps = {
   invalidErrorMessage: '',
   onChange: null,
   onKeyUp: null,
+  onKeyDown: null,
   onFocus: null,
   onBlur: null,
   autoComplete: '',

--- a/react/input/TextField.jsx
+++ b/react/input/TextField.jsx
@@ -68,10 +68,9 @@ class TextField extends React.Component {
           }
         }}
         onKeyUp={(e) => {
+          if (this.props.onKeyUp) this.props.onKeyUp(e);
           if (e.keyCode === 13) { // ENTER
             e.target.blur();
-          } else if (this.props.onKeyUp) {
-            this.props.onKeyUp(e);
           }
           // If an invalid message has already appeared via blur,
           // do the user a favor and update validity once they fix it (before another blur)


### PR DESCRIPTION
I don't know if we want exactly this, but I want to capture an `enter` in the parent component's `onKeyUp` so I changed this to always pass through the key event.

@emma-floored @hwigmore 