### PR TITLE
initial pre-commit hook for trying to warn if no generated javascript…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,13 @@ You can then run the documentation site with
 gulp server
 ```
 
-You can then navigate to the site at http://localhost:8080
+You can then navigate to the site at http://localhost:8080.
+
+### Contributing to Blocks
+
+The Blocks documentation site runs on GitHub pages and is generated with Jekyll. In order to make this work, we have to commit some generated JavaScript files (in particular, any changes in `react/` or `docs/_javascript` should result in an update to the built `*Preview.js` files in `docs/lib`). These are really easy to forget! There is now a pre-commit hook you can set up which will remind you if you have made changes in `react/` or `docs/_javascript` and are not committing `docs/lib/*.js` files as well. To set it up, just run
+
+```
+./bin/link_hooks
+```
+and say `y` at the prompt!

--- a/bin/link_hooks
+++ b/bin/link_hooks
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd "$(dirname $0)/.."
+blocks_dir=$(pwd)
+hooks=("pre-commit")
+
+for hook in ${hooks[@]}; do
+  read -p "link $hook hook? [y]/n: " response
+  if [ "$response" == "" ] || [ "$response" == "y" ] || [ "$response" == "Y" ]; then
+    ln -is $blocks_dir/hooks/$hook $blocks_dir/.git/hooks/$hook
+  fi
+done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -15,7 +15,7 @@ generated_files=()
 for i in ${edited_files[@]}
 do
   [[ $i == react/*.jsx ]] && edited_react_components+=($i)
-  [[ $i == _javascript/*.jsx ]] && edited_previews+=($i)
+  [[ $i == docs/_javascript/*.jsx ]] && edited_previews+=($i)
   [[ $i == docs/lib/*.js ]] && generated_files+=($i)
 done
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# pre-commit hook to verify that generated files have been added
+# if React component files were changed
+#
+# Currently not very smart - will not catch cases where you added
+# some generated files but missed others.
+
+edited_files=($(git diff-index --cached HEAD | awk '{print $6}'))
+
+edited_react_components=()
+edited_previews=()
+generated_files=()
+
+for i in ${edited_files[@]}
+do
+  [[ $i == react/*.jsx ]] && edited_react_components+=($i)
+  [[ $i == _javascript/*.jsx ]] && edited_previews+=($i)
+  [[ $i == docs/lib/*.js ]] && generated_files+=($i)
+done
+
+did_edit_react=${#edited_react_components[@]}
+did_edit_previews=${#edited_previews[@]}
+did_generate_files=${#generated_files[@]}
+
+if ([ $did_edit_react -gt 0 ] || [ $did_edit_previews -gt 0 ]) && [ $did_generate_files == 0 ]
+then
+  echo -e "\033[1;92mBLOCKS\033[0m Warning: You may not have included all necessary generated files."
+  echo "=== Please run 'gulp server' and add to your commit any additional files it produces."
+  echo "=== Try again with -n to bypass this pre-commit hook."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
… files were added

@joshkarges @hwigmore @Jinsoo94 

To test, run `./bin/link_hooks` and say `y`, then try changing stuff and committing without adding generated `.js` files.

Should look like:
<img width="632" alt="screen shot 2018-09-28 at 4 08 19 pm" src="https://user-images.githubusercontent.com/7839369/46231317-76e3e880-c339-11e8-82f1-3e0040ef5e39.png">
 