### PR TITLE
[FIX] Updates to dropdowns, popover menus, text fields

### DIFF
--- a/blocks-styles/dropdowns.styl
+++ b/blocks-styles/dropdowns.styl
@@ -15,10 +15,6 @@
   position: relative;
   height: 40px;
   border-radius: $base-border-radius;
-  font-size: 14px;
-  font-weight: $normal-weight;
-  line-height: 18px;
-  text-align: left;
   padding: 0 48px 0 16px;
   margin: 0;
   cursor: pointer;
@@ -28,7 +24,7 @@
 
   background-color: $ui-00;
   border: 1px solid $ui-03;
-  color: $text-01;
+  blxUIPlaceholder();
 
   &::after {
     position: absolute;
@@ -98,10 +94,18 @@
   }
 }
 
-.blx-dropdown-text {
+.blx-dropdown-text, .blx-dropdown-placeholder {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.blx-dropdown-text {
+  color: $text-01;
+}
+
+.blx-dropdown-placeholder {
+  color: $ui-07;
 }
 
 .blx-dropdown-menu {
@@ -119,13 +123,18 @@
   box-shadow: 0 3px 6px 0 $interactive-shadow;
 }
 
+.blx-dropdown-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 .blx-dropdown-item {
   background: transparent;
   
   a, button {
-    display: flex;
+    display: block;
     width: 100%;
-    height: 100%;
+    height: 40px;
     padding: 8px 16px;
     cursor: pointer;
     background: transparent;

--- a/blocks-styles/popovers.styl
+++ b/blocks-styles/popovers.styl
@@ -33,7 +33,7 @@
 .blx-popover {
   min-width: auto;
   .blx-dropdown-menu {
-    min-width: 150px;
+    min-width: 124px;
     &::before {
       content: "";
       position: absolute;

--- a/blocks-styles/text-fields.styl
+++ b/blocks-styles/text-fields.styl
@@ -22,11 +22,15 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-family: $sans-serif-font-family;
+    
+    &::placeholder {
+      blxUIPlaceholder();
+    }
   }
 
   input[type="date"] {
     position: relative;
-    width: 166px;
+    width: 176px;
 
     &::before, &::after {
       content: "";

--- a/blocks-styles/typography.styl
+++ b/blocks-styles/typography.styl
@@ -72,6 +72,18 @@ blxH6() {
   line-height: 26px;
 }
 
+blxUIText() {
+  font-weight: $normal-weight;
+  font-size: 14px;
+  line-height: 18px;
+  color: $text-01;
+}
+
+blxUIPlaceholder() {
+  blxUIText();
+  color: $ui-07;
+}
+
 // use those mixins to define our base text styles
 
 p, label {
@@ -126,10 +138,7 @@ h6 {
 }
 
 .blx-ui-text {
-  font-weight: $normal-weight;
-  font-size: 14px;
-  line-height: 18px;
-  color: $text-01;
+  blxUIText();
 }
 
 .blx-body-caps {

--- a/blocks.css
+++ b/blocks.css
@@ -1042,10 +1042,6 @@ a.blx-button {
   position: relative;
   height: 40px;
   border-radius: 7px;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 18px;
-  text-align: left;
   padding: 0 48px 0 16px;
   margin: 0;
   cursor: pointer;
@@ -1056,8 +1052,13 @@ a.blx-button {
   background-color: var(--ui-00, #fdfefd);
   border: 1px solid #edf0ee;
   border: 1px solid var(--ui-03, #edf0ee);
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
   color: #2b3836;
   color: var(--text-01, #2b3836);
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
 }
 .blx-dropdown-trigger::after {
   position: absolute;
@@ -1144,10 +1145,19 @@ a.blx-button {
 .blx-dropdown-trigger .blx-icon + span {
   margin: 10px 0;
 }
-.blx-dropdown-text {
+.blx-dropdown-text,
+.blx-dropdown-placeholder {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.blx-dropdown-text {
+  color: #2b3836;
+  color: var(--text-01, #2b3836);
+}
+.blx-dropdown-placeholder {
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
 }
 .blx-dropdown-menu {
   position: absolute;
@@ -1165,13 +1175,17 @@ a.blx-button {
   box-shadow: 0 3px 6px 0 rgba(0,72,51,0.25);
   box-shadow: 0 3px 6px 0 var(--interactive-shadow, rgba(0,72,51,0.25));
 }
+.blx-dropdown-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
 .blx-dropdown-item {
   background: transparent;
 }
 .blx-dropdown-item a {
-  display: flex;
+  display: block;
   width: 100%;
-  height: 100%;
+  height: 40px;
   padding: 8px 16px;
   cursor: pointer;
   background: transparent;
@@ -1189,9 +1203,9 @@ a.blx-button {
   color: var(--text-01, #2b3836);
 }
 .blx-dropdown-item button {
-  display: flex;
+  display: block;
   width: 100%;
-  height: 100%;
+  height: 40px;
   padding: 8px 16px;
   cursor: pointer;
   background: transparent;
@@ -1338,7 +1352,7 @@ a.blx-button {
   min-width: auto;
 }
 .blx-popover .blx-dropdown-menu {
-  min-width: 150px;
+  min-width: 124px;
 }
 .blx-popover .blx-dropdown-menu::before {
   content: "";
@@ -2021,9 +2035,45 @@ a.blx-button {
   text-overflow: ellipsis;
   font-family: Graphik Web;
 }
+.blx-text-field input::-webkit-input-placeholder {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  color: #2b3836;
+  color: var(--text-01, #2b3836);
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
+}
+.blx-text-field input:-ms-input-placeholder {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  color: #2b3836;
+  color: var(--text-01, #2b3836);
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
+}
+.blx-text-field input::-ms-input-placeholder {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  color: #2b3836;
+  color: var(--text-01, #2b3836);
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
+}
+.blx-text-field input::placeholder {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  color: #2b3836;
+  color: var(--text-01, #2b3836);
+  color: #aab7b2;
+  color: var(--ui-07, #aab7b2);
+}
 .blx-text-field input[type="date"] {
   position: relative;
-  width: 166px;
+  width: 176px;
 }
 .blx-text-field input[type="date"]::before,
 .blx-text-field input[type="date"]::after {

--- a/docs/_javascript/DropdownPreview.jsx
+++ b/docs/_javascript/DropdownPreview.jsx
@@ -29,7 +29,9 @@ class DropdownPreview extends React.Component {
                     { value: 'option1', text: 'One option' },
                     { value: 'option2', text: 'Another option', href: '#' },
                     { value: 'option3', text: 'Best option' },
-                    { value: 'option4', element: <div><span className="blx-icon blx-icon-plus"/>Custom element</div>, key: 'option4' }
+                    { value: 'option4', element: <div><span className="blx-icon blx-icon-plus"/>Custom element</div>, key: 'option4' },
+                    { value: 'option5', text: 'Different option' },
+                    { value: 'option6', text: 'Longer named option that should overflow' }
                   ]
                 }
               />

--- a/docs/_javascript/PopoverPreview.jsx
+++ b/docs/_javascript/PopoverPreview.jsx
@@ -11,7 +11,7 @@ const exampleOptions = [
     onClick: () => {}
   },
   {
-    text: 'Disabled Action',
+    text: 'Long Named Disabled Action',
     disabled: true,
     onClick: () => {}
   },
@@ -22,6 +22,14 @@ const exampleOptions = [
   {
     element: <span>More than text<span className="blx-icon blx-icon-plus" /></span>,
     key: 'customItem',
+    onClick: () => {}
+  },
+  {
+    text: 'Another Action',
+    onClick: () => {}
+  },
+  {
+    text: 'One More Action',
     onClick: () => {}
   }
 ];

--- a/docs/components/dropdowns.html
+++ b/docs/components/dropdowns.html
@@ -6,38 +6,11 @@ version: v.0
 definition: An input that allows users to make a single selection from a pre-defined list of familar and/or quantitative options. Use radio buttons instead when the user needs to scan, compare, and evaluate multiple similar and/or qualitative options.
 ---
 
-{% capture example %}
-  <div class="blx-dropdown-wrapper">
-    <div class="blx-dropdown">
-      <p class="blx-ui-text">Here is a dropdown</p>
-      <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-active">
-        <span class="blx-dropdown-text">
-          Choose an option
-        </span>
-      </button>
-      <ul class="blx-dropdown-menu">
-        <li class="blx-dropdown-item">
-          <button>Button option</button>
-        </li>
-        <li class="blx-dropdown-item">
-          <a href="#">Link option</a>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <button>Button option 2</button>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <a href="#">Link option 2</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-{% endcapture %}
-
 {% capture dropdown_trigger_example %}
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -49,7 +22,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-hover">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -61,7 +34,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-focus">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -85,7 +58,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger" title="This is a really long title that will overflow">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           This is a really long title that will overflow
         </span>
       </button>
@@ -97,7 +70,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-disabled">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -110,7 +83,7 @@ definition: An input that allows users to make a single selection from a pre-def
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger">
         <span class="blx-icon blx-icon-plus"></span>
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -122,7 +95,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -131,7 +104,7 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -144,7 +117,7 @@ definition: An input that allows users to make a single selection from a pre-def
     <div class="blx-dropdown">
       <p class="blx-ui-text">Dropdown label</p>
       <button class="blx-dropdown-trigger">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -154,7 +127,7 @@ definition: An input that allows users to make a single selection from a pre-def
     <div class="blx-dropdown">
       <p class="blx-ui-text">Dropdown label</p>
       <button class="blx-dropdown-trigger">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
@@ -166,21 +139,63 @@ definition: An input that allows users to make a single selection from a pre-def
   <div class="blx-dropdown-wrapper">
     <div class="blx-dropdown">
       <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-active">
-        <span class="blx-dropdown-text">
+        <span class="blx-dropdown-placeholder">
           Choose an option
         </span>
       </button>
-      <ul class="blx-dropdown-menu">
-        <li class="blx-dropdown-item">
-          <button>One option</button>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <a href="#">Disabled option</a>
-        </li>
-        <li class="blx-dropdown-item blx-hover">
-          <button>Best option</button>
-        </li>
-      </ul>
+      <div class="blx-dropdown-menu">
+        <ul class="blx-dropdown-list">
+          <li class="blx-dropdown-item">
+            <button>One option</button>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <a href="#">Disabled option</a>
+          </li>
+          <li class="blx-dropdown-item blx-hover">
+            <button>Best option</button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endcapture %}
+
+{% capture example %}
+  <div class="blx-dropdown-wrapper">
+    <div class="blx-dropdown">
+      <p class="blx-ui-text">Here is a dropdown</p>
+      <button class="blx-dropdown-trigger blx-dropdown-trigger-placeholder blx-active">
+        <span class="blx-dropdown-placeholder">
+          Choose an option
+        </span>
+      </button>
+      <div class="blx-dropdown-menu">
+        <ul class="blx-dropdown-list">
+          <li class="blx-dropdown-item">
+            <button>Button option</button>
+          </li>
+          <li class="blx-dropdown-item">
+            <a href="#">Link option</a>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <button>Button option 2</button>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <a href="#">Link option 2</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="blx-dropdown-wrapper">
+    <div class="blx-dropdown">
+      <p class="blx-ui-text">Filled example</p>
+      <button class="blx-dropdown-trigger">
+        <span class="blx-dropdown-text">
+          Selected option
+        </span>
+      </button>
     </div>
   </div>
 {% endcapture %}

--- a/docs/components/popovers.html
+++ b/docs/components/popovers.html
@@ -13,20 +13,22 @@ definition: An inline dropdown menu used to show the user relevant information o
       <button class="blx-popover-trigger">
         <span class="blx-icon blx-icon-more-horizontal"></span>
       </button>
-      <ul class="blx-dropdown-menu blx-popover-is-left">
-        <li class="blx-dropdown-item ">
-          <button>Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <button>Disabled Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-hover">
-          <button>Correct Action</button>
-        </li>
-        <li class="blx-dropdown-item ">
-          <button>Another one</button>
-        </li>
-      </ul>
+      <div class="blx-dropdown-menu blx-popover-is-left">
+        <ul class="blx-dropdown-list">
+          <li class="blx-dropdown-item ">
+            <button>Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <button>Disabled Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-hover">
+            <button>Correct Action</button>
+          </li>
+          <li class="blx-dropdown-item ">
+            <button>Another one</button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 {% endcapture %}
@@ -38,20 +40,22 @@ definition: An inline dropdown menu used to show the user relevant information o
       <button class="blx-popover-trigger">
         <span class="blx-icon blx-icon-more-horizontal"></span>
       </button>
-      <ul class="blx-dropdown-menu blx-popover-is-right">
-        <li class="blx-dropdown-item ">
-          <button>Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <button>Disabled Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-hover">
-          <button>Correct Action</button>
-        </li>
-        <li class="blx-dropdown-item ">
-          <button>Another one</button>
-        </li>
-      </ul>
+      <div class="blx-dropdown-menu blx-popover-is-right">
+        <ul class="blx-dropdown-list">
+          <li class="blx-dropdown-item ">
+            <button>Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <button>Disabled Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-hover">
+            <button>Correct Action</button>
+          </li>
+          <li class="blx-dropdown-item ">
+            <button>Another one</button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 {% endcapture %}
@@ -74,20 +78,22 @@ definition: An inline dropdown menu used to show the user relevant information o
       <button class="blx-popover-trigger">
         <span class="blx-icon blx-icon-down"></span>
       </button>
-      <ul class="blx-dropdown-menu blx-popover-is-right">
-        <li class="blx-dropdown-item ">
-          <button>Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-disabled">
-          <button>Disabled Action</button>
-        </li>
-        <li class="blx-dropdown-item blx-hover">
-          <button>Correct Action</button>
-        </li>
-        <li class="blx-dropdown-item ">
-          <button>Another one</button>
-        </li>
-      </ul>
+      <div class="blx-dropdown-menu blx-popover-is-right">
+        <ul class="blx-dropdown-list">
+          <li class="blx-dropdown-item ">
+            <button>Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-disabled">
+            <button>Disabled Action</button>
+          </li>
+          <li class="blx-dropdown-item blx-hover">
+            <button>Correct Action</button>
+          </li>
+          <li class="blx-dropdown-item ">
+            <button>Another one</button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 {% endcapture %}

--- a/react/dropdowns/Dropdown.jsx
+++ b/react/dropdowns/Dropdown.jsx
@@ -8,12 +8,13 @@ const keyControlledMenu = require('../wrappers/keyControlledMenu.jsx');
 const DropdownMenu = (props) => {
   let content = props.text;
   let triggerClassNames = 'blx-dropdown-trigger';
+  let triggerContentClassNames = 'blx-dropdown-placeholder';
 
   if (props.isOpen) triggerClassNames += ' blx-active';
   if (props.isDisabled) triggerClassNames += ' blx-disabled';
-  if (props.value) triggerClassNames += ' blx-dropdown-trigger-placeholder';
 
   if (props.value) {
+    triggerContentClassNames = 'blx-dropdown-text';
     for (let i = 0; i < props.options.length; i++) {
       const option = props.options[i];
       if (option.value === props.value) {
@@ -36,7 +37,7 @@ const DropdownMenu = (props) => {
       { props.icon && 
         <span className={`blx-icon blx-icon-${props.icon}`} />
       }
-      <span className="blx-dropdown-text">{ content }</span>
+      <span className={triggerContentClassNames}>{ content }</span>
     </button>
   );
 
@@ -52,20 +53,22 @@ const DropdownMenu = (props) => {
             </div>
         }
         { trigger }
-        <ul className={menuClasses}>
-          {
-            props.options.map((option, idx) => (
-              <DropdownItem
-                key={option.text || option.key}
-                option={option}
-                ref={props.optionsRefs[idx]}
-                onKeyDown={props.onKeyDown}
-                onKeyUp={props.onKeyUp}
-                onSelect={props.onSelect}
-              />
-            ))
-          }
-        </ul>
+        <div className={menuClasses}>
+          <ul className="blx-dropdown-list">
+            {
+              props.options.map((option, idx) => (
+                <DropdownItem
+                  key={option.text || option.key}
+                  option={option}
+                  ref={props.optionsRefs[idx]}
+                  onKeyDown={props.onKeyDown}
+                  onKeyUp={props.onKeyUp}
+                  onSelect={props.onSelect}
+                />
+              ))
+            }
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/react/dropdowns/DropdownItem.jsx
+++ b/react/dropdowns/DropdownItem.jsx
@@ -29,6 +29,7 @@ class DropdownItem extends React.Component {
         href={this.props.option.href}
         target={this.props.option.newTab ? '_blank' : null}
         disabled={this.props.option.disabled}
+        title={this.props.option.text}
         onKeyDown={this.onKeyDown}
         onKeyUp={this.onKeyUp}
         onClick={this.onSelect}
@@ -42,6 +43,7 @@ class DropdownItem extends React.Component {
     return (
       <button
         disabled={this.props.option.disabled}
+        title={this.props.option.text}
         onKeyDown={this.onKeyDown}
         onKeyUp={this.onKeyUp}
         onClick={this.onSelect}

--- a/react/dropdowns/PopoverMenu.jsx
+++ b/react/dropdowns/PopoverMenu.jsx
@@ -31,20 +31,22 @@ const PopoverMenu = (props) => {
         >
           <span className={`blx-icon blx-icon-${props.icon}`} />
         </button>
-        <ul className={menuClasses}>
-          {
-            props.options.map((option, idx) => (
-              <DropdownItem
-                key={option.text || option.key}
-                option={option}
-                ref={props.optionsRefs[idx]}
-                onKeyDown={props.onKeyDown}
-                onKeyUp={props.onKeyUp}
-                onSelect={props.onSelect}
-              />
-            ))
-          }
-        </ul>
+        <div className={menuClasses}>
+          <ul className="blx-dropdown-list">
+            {
+              props.options.map((option, idx) => (
+                <DropdownItem
+                  key={option.text || option.key}
+                  option={option}
+                  ref={props.optionsRefs[idx]}
+                  onKeyDown={props.onKeyDown}
+                  onKeyUp={props.onKeyUp}
+                  onSelect={props.onSelect}
+                />
+              ))
+            }
+          </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
@Jinsoo94 @hwigmore 

- text fields
  - style placeholder text
- dropdowns/popovers
  - style placeholder text
  - wrap items in a div for scrolling
  - give dropdown items titles (for tooltips)
  - shrink min width of popovers a little

Scrolling:
<img width="400" alt="screen shot 2018-10-29 at 6 25 34 pm" src="https://user-images.githubusercontent.com/7839369/47685850-8c556800-dbae-11e8-920b-470a4fbbe561.png">

Fixed popover overflow:
<img width="332" alt="screen shot 2018-10-29 at 7 13 07 pm" src="https://user-images.githubusercontent.com/7839369/47685890-b4dd6200-dbae-11e8-8df5-e40054942226.png">
