### PR TITLE
fix sortable list behavior

### DIFF
--- a/blocks-styles/sortable-list.styl
+++ b/blocks-styles/sortable-list.styl
@@ -3,26 +3,32 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  
+
   .blx-sortable-list-item {
     position: relative;
     display: flex;
     justify-content: space-between;
-    
-    &.dragging {
+    border-color: transparent;
+    border-style: solid;
+    border-width: 2px 0 2px 0;
+
+    &.blx-dragging {
       background-color: $selection;
     }
-    &.dragover {
-      background-color: $ui-04;
+    &.blx-dragover-top {
+      border-top: 2px solid $ui-08;
     }
-    
+    &.blx-dragover-bottom {
+      border-bottom: 2px solid $ui-08;
+    }
+
     .blx-icon-drag {
       position: relative;
       right: 0;
       margin: 8px;
       cursor: move;
       background-color: $interactive;
-      
+
       &:hover, &.blx-hover {
         background-color: $interactive-hover;
       }

--- a/blocks.css
+++ b/blocks.css
@@ -1699,14 +1699,21 @@ a.blx-button {
   position: relative;
   display: flex;
   justify-content: space-between;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 2px 0 2px 0;
 }
-.blx-sortable-list .blx-sortable-list-item.dragging {
+.blx-sortable-list .blx-sortable-list-item.blx-dragging {
   background-color: #49a1ff;
   background-color: var(--selection, #49a1ff);
 }
-.blx-sortable-list .blx-sortable-list-item.dragover {
-  background-color: #d9e1e0;
-  background-color: var(--ui-04, #d9e1e0);
+.blx-sortable-list .blx-sortable-list-item.blx-dragover-top {
+  border-top: 2px solid #91a49e;
+  border-top: 2px solid var(--ui-08, #91a49e);
+}
+.blx-sortable-list .blx-sortable-list-item.blx-dragover-bottom {
+  border-bottom: 2px solid #91a49e;
+  border-bottom: 2px solid var(--ui-08, #91a49e);
 }
 .blx-sortable-list .blx-sortable-list-item .blx-icon-drag {
   position: relative;

--- a/docs/_javascript/SortableListPreview.jsx
+++ b/docs/_javascript/SortableListPreview.jsx
@@ -6,7 +6,7 @@ const getPreviewComponent = require('./common/getPreviewComponent.jsx');
 const SortableList = require('../../react/lists/SortableList.jsx');
 
 const SortableListPreview = () => (
-  <div>
+  <div className='sortable-list-preview'>
     <SortableList>
       <span>Item 1</span>
       <span>Item 2</span>

--- a/docs/_styl/page.styl
+++ b/docs/_styl/page.styl
@@ -179,3 +179,15 @@ html, body {
     color: $text-02;
   }
 }
+
+.sortable-list-preview {
+  width: 300px;
+  
+  .blx-sortable-list {
+    background-color: $ui-04;
+  }
+  
+  .blx-sortable-list-item {
+    padding: 8px 16px;
+  }
+}

--- a/docs/patterns/sortablelists.html
+++ b/docs/patterns/sortablelists.html
@@ -1,0 +1,14 @@
+---
+layout: componentSection
+title: Sortable Lists
+status: Design review
+version: v.0
+definition: TBD
+---
+
+<!-- React component preview -->
+<div class="l-flex-vertical doc-section">
+  <h4>React Components</h4>
+  <div id="react-preview"></div>
+</div>
+<script src="{{ "/lib/SortableListPreview.js" | relative_url }}"></script>

--- a/react/lists/SortableList.jsx
+++ b/react/lists/SortableList.jsx
@@ -25,7 +25,7 @@ class SortableList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.listDOM = null;
+    this.listDOM = React.createRef();
     this.source = null;
 
     this.onDragStart = this.onDragStart.bind(this);
@@ -36,20 +36,41 @@ class SortableList extends React.Component {
   }
 
   componentDidMount() {
-    if (this.listDOM) {
-      this.listDOM.addEventListener('dragstart', this.onDragStart);
-      this.listDOM.addEventListener('dragover', this.onDragOver);
-      this.listDOM.addEventListener('dragend', this.onDragEnd);
+    if (this.listDOM.current) {
+      this.listDOM.current.addEventListener('dragstart', this.onDragStart);
+      this.listDOM.current.addEventListener('dragover', this.onDragOver);
+      this.listDOM.current.addEventListener('dragend', this.onDragEnd);
     }
   }
 
+  // check whether a given DOM element is inside this sortable list at any depth
+  isInList(element) {
+    let node = element;
+    while (node) {
+      if (node === this.listDOM.current) return true;
+      node = node.parentNode;
+    }
+    return false;
+  }
+
+  // return the list element <li> that the given element is a child of
+  // for these lists, the actual draggable element is the icon, but
+  // we want to ignore the icons always and pretend like the list items
+  // are the draggable elements
+  getListElement(child) {
+    if (!this.isInList(child)) return null;
+    let node = child;
+    while (node && node.tagName !== 'LI') {
+      node = node.parentNode;
+    }
+    return node;
+  }
+
   getDragTarget(e) {
-    if (e.target.parentNode.parentNode !== this.listDOM) return null;
-    // for these lists, the actual draggable element is the icon, but
-    // we want to ignore the icons always and pretend like the list items
-    // are the draggable elements
-    if (e.target.className.indexOf('icon-drag') >= 0) return e.target.parentNode;
-    return e.target;
+    if (!this.isInList(e.target)) return null;
+    const listItem = this.getListElement(e.target);
+    if (listItem === this.source) return null;
+    return listItem;
   }
 
   onDragOver(e) {
@@ -57,14 +78,19 @@ class SortableList extends React.Component {
     e.preventDefault();
     const target = this.getDragTarget(e);
     if (!target) return;
-    addOrRemoveClass(target, 'dragover', true);
+    if (isBefore(this.source, target)) {
+      addOrRemoveClass(target, 'blx-dragover-top', true);
+    } else {
+      addOrRemoveClass(target, 'blx-dragover-bottom', true);
+    }
   }
 
   onDragLeave(e) {
     if (!this.source) return;
     const target = this.getDragTarget(e);
     if (!target) return;
-    addOrRemoveClass(target, 'dragover', false);
+    addOrRemoveClass(target, 'blx-dragover-top', false);
+    addOrRemoveClass(target, 'blx-dragover-bottom', false);
   }
 
   onDrop(e) {
@@ -72,16 +98,17 @@ class SortableList extends React.Component {
     e.preventDefault();
     const target = this.getDragTarget(e);
     if (!target) return;
-    let listChildren = Array.prototype.slice.call(this.listDOM.children);
+    let listChildren = Array.prototype.slice.call(this.listDOM.current.children);
     const sourceStartIndex = listChildren.indexOf(this.source);
     if (isBefore(this.source, target)) {
       target.parentNode.insertBefore(this.source, target);
     } else {
       target.parentNode.insertBefore(this.source, target.nextSibling);
     }
-    addOrRemoveClass(target, 'dragover', false);
-    addOrRemoveClass(this.source, 'dragging', false);
-    listChildren = Array.prototype.slice.call(this.listDOM.children);
+    addOrRemoveClass(target, 'blx-dragover-top', false);
+    addOrRemoveClass(target, 'blx-dragover-bottom', false);
+    addOrRemoveClass(this.source, 'blx-dragging', false);
+    listChildren = Array.prototype.slice.call(this.listDOM.current.children);
     const sourceEndIndex = listChildren.indexOf(this.source);
     this.props.onDrop(sourceStartIndex, sourceEndIndex);
     this.source = null;
@@ -90,10 +117,10 @@ class SortableList extends React.Component {
   onDragStart(e) {
     // the event target will be the icon, but we want to keep
     // track of the list item itself (the parent node)
-    if (e.target.className.indexOf('icon-drag') >= 0) {
+    if (e.target.className.indexOf('blx-icon-drag') >= 0) {
       this.source = e.target.parentNode;
       this.source.draggable = true;
-      addOrRemoveClass(this.source, 'dragging', true);
+      addOrRemoveClass(this.source, 'blx-dragging', true);
       e.dataTransfer.effectAllowed = 'move';
       e.dataTransfer.setData('text/html', this.source);
       e.dataTransfer.setDragImage(this.source, 275, 0);
@@ -102,7 +129,7 @@ class SortableList extends React.Component {
 
   onDragEnd(e) {
     if (!this.source) return;
-    addOrRemoveClass(this.source, 'dragging', false);
+    addOrRemoveClass(this.source, 'blx-dragging', false);
     this.source = null;
   }
 
@@ -111,7 +138,7 @@ class SortableList extends React.Component {
       <div>
         <ul
           className="blx-sortable-list"
-          ref={(el) => { this.listDOM = el; }}
+          ref={this.listDOM}
         >
           {
             this.props.children.map((child, idx) => (


### PR DESCRIPTION
@Jinsoo94 

- sortable lists should work in firefox now
- sortable lists shouldn't break so easily
- added lines to show where the item will drop
- can now drag over whole list item rather than having to hit the drag icon

I added sort of a fake preview page at http://localhost:8080/patterns/sortablelists/ (can't access by navigation) with a React component so you can test!