### PR TITLE
stopPropagation on closeOnClick toggle

### DIFF
--- a/react/wrappers/closeOnClick.jsx
+++ b/react/wrappers/closeOnClick.jsx
@@ -31,6 +31,7 @@ function closeOnClick(WrappedComponent) {
     }
 
     toggle(e) {
+      e.stopPropagation();
       e.preventDefault();
       if (this.state.isOpen) {
         this.close();


### PR DESCRIPTION
added stopPropagation to toggle in closeOnClick to prevent click on element that closeOnClick element is on top of