### PR TITLE
SortableList breaks if props.children is not an array 

### DIFF
--- a/packages/blocks-react/dist/lists/SortableList.js
+++ b/packages/blocks-react/dist/lists/SortableList.js
@@ -173,7 +173,7 @@ var SortableList = function (_React$Component) {
           className: 'blx-sortable-list ' + this.props.className,
           ref: this.listDOM
         },
-        this.props.children.map(function (child, idx) {
+        React.Children.map(this.props.children, function (child) {
           return React.createElement(
             'li',
             {

--- a/packages/blocks-react/lists/SortableList.jsx
+++ b/packages/blocks-react/lists/SortableList.jsx
@@ -141,7 +141,7 @@ class SortableList extends React.Component {
         ref={this.listDOM}
       >
         {
-          this.props.children.map((child, idx) => (
+          React.Children.map(this.props.children, child => (
             <li
               key={Math.random()}
               className="blx-sortable-list-item"
@@ -170,7 +170,7 @@ SortableList.propTypes = {
 SortableList.defaultProps = {
   className: '',
   style: null,
-  onDrop: () => {}
+  onDrop: () => { }
 };
 
 module.exports = SortableList;

--- a/packages/blocks-react/lists/SortableList.jsx
+++ b/packages/blocks-react/lists/SortableList.jsx
@@ -170,7 +170,7 @@ SortableList.propTypes = {
 SortableList.defaultProps = {
   className: '',
   style: null,
-  onDrop: () => { }
+  onDrop: () => {}
 };
 
 module.exports = SortableList;


### PR DESCRIPTION
`props.children` is not guaranteed to be an array. React.Children ensures that this will be an array.
It could be a function or an object for example

https://mxstbr.blog/2017/02/react-children-deepdive/