### PR TITLE
add justify content center to blx-button

### DIFF
--- a/packages/blocks-base/dist/blocks.css
+++ b/packages/blocks-base/dist/blocks.css
@@ -620,6 +620,7 @@ input[type=checkbox][name='blx-accordion-tab']:checked ~ .blx-accordion-content 
 .blx-button {
   position: relative;
   display: flex;
+  justify-content: center;
   height: 44px;
   max-width: 480px;
   min-width: 44px;

--- a/packages/blocks-base/package-lock.json
+++ b/packages/blocks-base/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-base",
-	"version": "0.1.13",
+	"version": "0.1.15",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/blocks-base/styles/buttons.styl
+++ b/packages/blocks-base/styles/buttons.styl
@@ -52,6 +52,7 @@ $button-danger-active-text-color = $secondary-00;
 .blx-button {
   position: relative;
   display: flex;
+  justify-content: center;
 
   height: $button-height;
   max-width: 480px;

--- a/packages/blocks-docs/package-lock.json
+++ b/packages/blocks-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blocks-docs",
-  "version": "0.1.14",
+  "version": "0.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/blocks-react/package-lock.json
+++ b/packages/blocks-react/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "blocks-react",
-	"version": "0.1.14",
+	"version": "0.1.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
[Clubhouse](https://app.clubhouse.io/blocks/story/34500/update-vertical-button-group-text-centering)

I tested it by changing wrapper class to `blx-v-button-group` in the doc site's inspector.