### PR TITLE
focus state of tooltip triggers on safari and firefox

### DIFF
--- a/packages/blocks-base/dist/blocks.css
+++ b/packages/blocks-base/dist/blocks.css
@@ -2669,6 +2669,9 @@ input[type="radio"]:hover + .blx-sub-tab {
   border: 2px solid #49a1ff;
   border: 2px solid var(--focus, #49a1ff);
 }
+.blx-tooltip-trigger::-moz-focus-inner {
+  border: 0;
+}
 .blx-tooltip-message,
 .blx-tooltip-titled-message {
   border-radius: 7px;

--- a/packages/blocks-base/styles/tooltips.styl
+++ b/packages/blocks-base/styles/tooltips.styl
@@ -21,6 +21,10 @@
     outline: none;
     border: 2px solid $focus;
   }
+  
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
 .blx-tooltip-message, .blx-tooltip-titled-message {

--- a/packages/blocks-react/dist/tooltips/Tooltip.js
+++ b/packages/blocks-react/dist/tooltips/Tooltip.js
@@ -20,7 +20,13 @@ var Tooltip = function Tooltip(props) {
     },
     React.createElement(
       'button',
-      { className: 'blx-tooltip-trigger', onClick: props.toggle },
+      {
+        className: 'blx-tooltip-trigger',
+        onClick: function onClick(e) {
+          e.target.closest('.blx-tooltip-trigger').focus();
+          props.toggle(e);
+        }
+      },
       props.trigger
     ),
     React.createElement(

--- a/packages/blocks-react/tooltips/Tooltip.jsx
+++ b/packages/blocks-react/tooltips/Tooltip.jsx
@@ -15,7 +15,13 @@ const Tooltip = (props) => {
       className={`blx-tooltip ${props.className}`}
       ref={props.forwardedRef}
     >
-      <button className="blx-tooltip-trigger" onClick={props.toggle}>
+      <button
+        className="blx-tooltip-trigger"
+        onClick={(e) => {
+          e.target.closest('.blx-tooltip-trigger').focus();
+          props.toggle(e);
+        }}
+      >
         {props.trigger}
       </button>
       <div className={messageClasses}>


### PR DESCRIPTION
[Clubhouse](https://app.clubhouse.io/blocks/story/36485/tooltip-x-browser-functionality)

Since mouse click doesn't trigger focus state, add a custom onclick listener and manual 
<img width="1084" alt="Screen Shot 2019-06-17 at 2 30 12 PM" src="https://user-images.githubusercontent.com/40768559/59629733-7e3e6280-9111-11e9-9f4d-bbb43ad4a4b0.png">
focusing.